### PR TITLE
Fix hash options passed to partials

### DIFF
--- a/src/main/php/com/handlebarsjs/PartialBlockHelper.class.php
+++ b/src/main/php/com/handlebarsjs/PartialBlockHelper.class.php
@@ -37,7 +37,11 @@ class PartialBlockHelper extends BlockNode {
     if (isset($this->options[0])) {
       $context= $context->newInstance($this->options[0]($this, $context, []));
     } else if ($this->options) {
-      $context= $context->newInstance($context->asTraversable($this->options));
+      $pass= [];
+      foreach ($context->asTraversable($this->options) as $key => $value) {
+        $pass[$key]= $value($this, $context, []);
+      }
+      $context= $context->newInstance($pass);
     }
 
     $source= $templates->source($this->name);

--- a/src/main/php/com/handlebarsjs/PartialNode.class.php
+++ b/src/main/php/com/handlebarsjs/PartialNode.class.php
@@ -1,8 +1,8 @@
 <?php namespace com\handlebarsjs;
 
+use com\github\mustache\Node;
 use lang\Value;
 use util\Objects;
-use com\github\mustache\Node;
 
 /**
  * Partials

--- a/src/main/php/com/handlebarsjs/PartialNode.class.php
+++ b/src/main/php/com/handlebarsjs/PartialNode.class.php
@@ -94,7 +94,11 @@ class PartialNode extends Node {
     if (isset($this->options[0])) {
       $context= $context->newInstance($this->options[0]($this, $context, []));
     } else if ($this->options) {
-      $context= $context->newInstance($context->asTraversable($this->options));
+      $pass= [];
+      foreach ($context->asTraversable($this->options) as $key => $value) {
+        $pass[$key]= $value($this, $context, []);
+      }
+      $context= $context->newInstance($pass);
     }
 
     $engine= $context->engine;

--- a/src/test/php/com/handlebarsjs/unittest/PartialBlockHelperTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/PartialBlockHelperTest.class.php
@@ -37,6 +37,14 @@ class PartialBlockHelperTest extends HelperTest {
   }
 
   #[@test]
+  public function block_can_reference_options_hash() {
+    $this->templates->add('layout', '{{title}} - {{name.en}}');
+    $this->assertEquals('Home - Tool', $this->evaluate('{{#> layout title="Home" name=theme.name}}Default{{/layout}}', [
+      'theme' => ['name' => ['en' => 'Tool']]
+    ]));
+  }
+
+  #[@test]
   public function partial_inside_each() {
     $this->templates->add('list', '[{{#each .}}<item>{{> @partial-block}}</item>{{/each}}]');
     $this->assertEquals(

--- a/src/test/php/com/handlebarsjs/unittest/PartialHelperTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/PartialHelperTest.class.php
@@ -1,0 +1,26 @@
+<?php namespace com\handlebarsjs\unittest;
+
+class PartialHelperTest extends HelperTest {
+
+  #[@test]
+  public function existing_partial() {
+    $this->templates->add('layout', 'My layout');
+    $this->assertEquals('My layout', $this->evaluate('{{> layout}}', []));
+  }
+
+  #[@test]
+  public function partial_contexts() {
+    $this->templates->add('layout', 'My layout for {{name.en}}');
+    $this->assertEquals('My layout for Tool', $this->evaluate('{{> layout theme}}', [
+      'theme' => ['name' => ['en' => 'Tool']]]
+    ));
+  }
+
+  #[@test]
+  public function partial_parameters() {
+    $this->templates->add('layout', 'My layout for {{name.en}}');
+    $this->assertEquals('My layout for Tool', $this->evaluate('{{> layout name=theme.name}}', [
+      'theme' => ['name' => ['en' => 'Tool']]]
+    ));
+  }
+}


### PR DESCRIPTION
For both partials (`{{> partial}}`) and partial blocks (`{{#> partial}}..{{/partial}}`), see https://handlebarsjs.com/partials.html

/cc @johannes85