### PR TITLE
Add support for escaping tags

### DIFF
--- a/src/main/php/com/handlebarsjs/HandlebarsParser.class.php
+++ b/src/main/php/com/handlebarsjs/HandlebarsParser.class.php
@@ -254,7 +254,7 @@ class HandlebarsParser extends AbstractMustacheParser {
         } while ($s > 0 && '\\' === $line[$s - 1]);
 
         if (false === $s) {
-          $text= str_replace('\\'.$state->start, $state->start, substr($line, $offset));
+          $text= substr($line, $offset);
           $tag= null;
           $offset= $length;
         } else {
@@ -265,7 +265,7 @@ class HandlebarsParser extends AbstractMustacheParser {
             $line.= $indent.$tokens->nextToken().$tokens->nextToken();
           }
           $length= strlen($line);
-          $text= str_replace('\\'.$state->start, $state->start, substr($line, $offset, $s - $offset));
+          $text= substr($line, $offset, $s - $offset);
           $tag= substr($line, $s + strlen($state->start), $e - $s - strlen($state->end));
           $offset= $e + strlen($state->end);
 
@@ -281,7 +281,7 @@ class HandlebarsParser extends AbstractMustacheParser {
 
         // Handle text
         if ('' !== $text) {
-          $state->target->add(new TextNode($text));
+          $state->target->add(new TextNode(str_replace('\\'.$state->start, $state->start, $text)));
         }
 
         // Handle tag

--- a/src/main/php/com/handlebarsjs/HandlebarsParser.class.php
+++ b/src/main/php/com/handlebarsjs/HandlebarsParser.class.php
@@ -254,7 +254,7 @@ class HandlebarsParser extends AbstractMustacheParser {
         } while ($s > 0 && '\\' === $line[$s - 1]);
 
         if (false === $s) {
-          $text= str_replace('\\{{', '{{', substr($line, $offset));
+          $text= str_replace('\\'.$state->start, $state->start, substr($line, $offset));
           $tag= null;
           $offset= $length;
         } else {
@@ -265,7 +265,7 @@ class HandlebarsParser extends AbstractMustacheParser {
             $line.= $indent.$tokens->nextToken().$tokens->nextToken();
           }
           $length= strlen($line);
-          $text= str_replace('\\{{', '{{', substr($line, $offset, $s - $offset));
+          $text= str_replace('\\'.$state->start, $state->start, substr($line, $offset, $s - $offset));
           $tag= substr($line, $s + strlen($state->start), $e - $s - strlen($state->end));
           $offset= $e + strlen($state->end);
 

--- a/src/main/php/com/handlebarsjs/HandlebarsParser.class.php
+++ b/src/main/php/com/handlebarsjs/HandlebarsParser.class.php
@@ -173,6 +173,11 @@ class HandlebarsParser extends AbstractMustacheParser {
         );
         return +1; // Skip "}"
       } else if ('/' === $tag[2]) {
+        $name= substr($tag, 3);
+        if ($name !== $state->target->name()) {
+          throw new TemplateFormatException('Illegal nesting, expected {{{{/'.$state->target->name().'}}}}, have {{{{/'.$name.'}}}}');
+        }
+
         $state->target= array_pop($state->parents);
         return +2; // Skip "}}"
       } else {

--- a/src/main/php/com/handlebarsjs/HandlebarsParser.class.php
+++ b/src/main/php/com/handlebarsjs/HandlebarsParser.class.php
@@ -1,7 +1,16 @@
 <?php namespace com\handlebarsjs;
 
-use com\github\mustache\{AbstractMustacheParser, CommentNode, IteratorNode, TemplateFormatException, VariableNode};
+use com\github\mustache\{
+  AbstractMustacheParser,
+  CommentNode,
+  IteratorNode,
+  VariableNode,
+  TextNode,
+  TemplateFormatException,
+  ParseState
+};
 use lang\MethodNotImplementedException;
+use text\Tokenizer;
 
 /**
  * Parses handlebars templates
@@ -154,7 +163,7 @@ class HandlebarsParser extends AbstractMustacheParser {
       );
     });
 
-    // triple mustache for unescaped
+    // triple mustache for unescaped, quadruple for raw
     $this->withHandler('{', false, function($tag, $state, $parse) {
       $parsed= $parse->options(trim(substr($tag, 1)));
       $state->target->add('.' === $parsed[0]
@@ -193,11 +202,95 @@ class HandlebarsParser extends AbstractMustacheParser {
   }
 
   /**
-   * Returns parsing target
+   * Parse a template
    *
-   * @return com.github.mustache.NodeList
+   * @param  string $template The template as a string
+   * @param  string $start Initial start tag, defaults to "{{"
+   * @param  string $end Initial end tag, defaults to "}}"
+   * @param  string $indent What to prefix before each line
+   * @return com.github.mustache.Node The parsed template
+   * @throws com.github.mustache.TemplateFormatException
    */
-  protected function target() {
-    return new Nodes();
+  public function parse(Tokenizer $tokens, $start= '{{', $end= '}}', $indent= '') {
+    $state= new ParseState();
+    $state->target= new Nodes();
+    $state->start= $start;
+    $state->end= $end;
+    $state->parents= [];
+    $standalone= implode('', array_keys($this->standalone));
+
+    // Tokenize template
+    $tokens->delimiters= "\n";
+    $tokens->returnDelims= true;
+    while ($tokens->hasMoreTokens()) {
+      $token= $tokens->nextToken();
+
+      // Yield empty lines as separate text nodes
+      if ("\n" === $token) {
+        $state->target->add(new TextNode($indent.$token));
+        continue;
+      }
+
+      $line= $indent.$token.$tokens->nextToken();
+      $offset= 0;
+      $length= strlen($line);
+      do {
+        $state->padding= '';
+
+        // Find first unescaped `{{` starting at $offset
+        $o= $offset;
+        do {
+          $s= strpos($line, $state->start, $o);
+          $o= $s + 1;
+        } while ($s > 0 && '\\' === $line[$s - 1]);
+
+        if (false === $s) {
+          $text= str_replace('\\{{', '{{', substr($line, $offset));
+          $tag= null;
+          $offset= $length;
+        } else {
+          while (false === ($e= strpos($line, $state->end, $s + strlen($state->start)))) {
+            if (!$tokens->hasMoreTokens()) {
+              throw new TemplateFormatException('Unclosed '.$state->start.', expecting '.$state->end);
+            }
+            $line.= $indent.$tokens->nextToken().$tokens->nextToken();
+          }
+          $text= str_replace('\\{{', '{{', substr($line, $offset, $s - $offset));
+          $tag= substr($line, $s + strlen($state->start), $e - $s - strlen($state->end));
+          $offset= $e + strlen($state->end);
+
+          // Check for standalone tags on a line by themselves
+          if (0 === strcspn($tag, $standalone)) {
+            if ('' === trim(substr($line, 0, $s).substr($line, $offset))) {
+              $offset= $length;
+              $state->padding= substr($line, 0, $s);
+              $text= '';
+            }
+          }
+        }
+
+        // Handle text
+        if ('' !== $text) {
+          $state->target->add(new TextNode($text));
+        }
+
+        // Handle tag
+        if (null === $tag) {
+          continue;
+        } else if (isset($this->handlers[$tag[0]])) {
+          $f= $this->handlers[$tag[0]];
+        } else {
+          $f= $this->handlers[null];
+        }
+        $offset+= $f($tag, $state, $this);
+      } while ($offset < $length);
+    }
+
+    // Check for unclosed sections
+    if (!empty($state->parents)) {
+      throw new TemplateFormatException('Unclosed section '.$state->target->name());
+    }
+
+    return $state->target;
   }
 }

--- a/src/main/php/com/handlebarsjs/RawSection.class.php
+++ b/src/main/php/com/handlebarsjs/RawSection.class.php
@@ -1,0 +1,42 @@
+<?php namespace com\handlebarsjs;
+
+use com\github\mustache\NodeList;
+
+/**
+ * A raw section starts with `{{{{...}}}}` and ends with `{{{{/...}}}}`.
+ *
+ * @see  https://handlebarsjs.com/guide/expressions.html#escaping-handlebars-expressions
+ */
+class RawSection extends NodeList {
+  private $name;
+
+  /** @param string $name */
+  public function __construct($name) {
+    parent::__construct([]);
+    $this->name= $name;
+  }
+
+  /** @return string */
+  public function name() { return $this->name; }
+
+  /**
+   * Evaluates this node
+   *
+   * @param  com.github.mustache.Context $context the rendering context
+   * @param  io.streams.OutputStream $out
+   */
+  public function write($context, $out) {
+    foreach ($this->nodes as $node) {
+      $out->write($node->__toString());
+    }
+  }
+
+  /**
+   * Overload (string) cast
+   *
+   * @return string
+   */
+  public function __toString() {
+    return '{{{{'.$this->name.'}}}}'.trim(implode('', $this->nodes)).'{{{{/'.$this->name.'}}}}';
+  }
+}

--- a/src/test/php/com/handlebarsjs/unittest/EscapingTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/EscapingTest.class.php
@@ -46,4 +46,12 @@ class EscapingTest {
   public function backslash_mustaches_and_unescaped_mustache() {
     Assert::equals('Escaped {{a}}{{b}}+{{c}} tags', $this->render('Escaped \\{{a}}\\{{b}}{{and}}\\{{c}} tags', ['and' => '+']));
   }
+
+  #[Test]
+  public function raw_blocks() {
+    Assert::equals(
+      'Handlebars syntax here: {{handlebars}}!',
+      $this->render('Handlebars syntax here: {{{{raw}}}}{{handlebars}}{{{{/raw}}}}!')
+    );
+  }
 }

--- a/src/test/php/com/handlebarsjs/unittest/EscapingTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/EscapingTest.class.php
@@ -1,0 +1,49 @@
+<?php namespace com\handlebarsjs\unittest;
+
+use com\handlebarsjs\HandlebarsEngine;
+use unittest\{Assert, Test};
+
+/** See https://handlebarsjs.com/guide/expressions.html#escaping-handlebars-expressions */
+class EscapingTest {
+
+  /**
+   * Render a template with a list of variables
+   *
+   * @param  string $template
+   * @param  [:var] $helpers
+   * @return string
+   */
+  protected function render($template, $variables= []) {
+    return (new HandlebarsEngine())->render($template, $variables);
+  }
+
+  #[Test]
+  public function backslash_mustache() {
+    Assert::equals('{{escaped}}', $this->render('\\{{escaped}}'));
+  }
+
+  #[Test]
+  public function backslash_mustache_inside_text() {
+    Assert::equals('An {{escaped}} tag', $this->render('An \\{{escaped}} tag'));
+  }
+
+  #[Test]
+  public function backslash_mustache_at_beginning() {
+    Assert::equals('{{escaped}} tags', $this->render('\\{{escaped}} tags'));
+  }
+
+  #[Test]
+  public function backslash_mustache_at_end() {
+    Assert::equals('It\'s {{escaped}}', $this->render('It\'s \\{{escaped}}'));
+  }
+
+  #[Test]
+  public function backslash_mustaches() {
+    Assert::equals('Escaped {{a}}{{b}}+{{c}} tags', $this->render('Escaped \\{{a}}\\{{b}}+\\{{c}} tags'));
+  }
+
+  #[Test]
+  public function backslash_mustaches_and_unescaped_mustache() {
+    Assert::equals('Escaped {{a}}{{b}}+{{c}} tags', $this->render('Escaped \\{{a}}\\{{b}}{{and}}\\{{c}} tags', ['and' => '+']));
+  }
+}


### PR DESCRIPTION
See https://handlebarsjs.com/guide/expressions.html#escaping-handlebars-expressions

* [x] `\{{escaped}}`
* [x] `{{{{raw}}}}...{{{{/raw}}}}`