### PR TITLE
Add support for `each` with block params

### DIFF
--- a/src/main/php/com/handlebarsjs/BlockParams.class.php
+++ b/src/main/php/com/handlebarsjs/BlockParams.class.php
@@ -36,7 +36,7 @@ class BlockParams implements Value {
 
   /** @return string */
   public function hashCode() {
-    return Objects::hashOf($this->name);
+    return Objects::hashOf($this->names);
   }
 
   /** @return string */

--- a/src/main/php/com/handlebarsjs/BlockParams.class.php
+++ b/src/main/php/com/handlebarsjs/BlockParams.class.php
@@ -25,18 +25,6 @@ class BlockParams implements Value {
   }
 
   /**
-   * Invocation overloading
-   *
-   * @param  com.github.mustache.Node $node
-   * @param  com.github.mustache.Context $context
-   * @param  var[] $options
-   * @return var
-   */
-  public function __invoke($node, $context, $options) {
-    return [$this->names[0] => $context]; // FIXME
-  }
-
-  /**
    * Compares
    *
    * @param  var $value

--- a/src/main/php/com/handlebarsjs/BlockParams.class.php
+++ b/src/main/php/com/handlebarsjs/BlockParams.class.php
@@ -1,15 +1,18 @@
 <?php namespace com\handlebarsjs;
 
-class Alias implements \lang\Value {
-  private $name;
+use lang\Value;
+use util\Objects;
+
+class BlockParams implements Value {
+  public $names;
 
   /**
    * Creates a new constant
    *
-   * @param  var $name
+   * @param  string[] $names
    */
-  public function __construct($name) {
-    $this->name= $name;
+  public function __construct($names) {
+    $this->names= $names;
   }
 
   /**
@@ -18,7 +21,7 @@ class Alias implements \lang\Value {
    * @return string
    */
   public function __toString() {
-    return 'as |'.$this->name.'|';
+    return 'as |'.implode(' ', $this->names).'|';
   }
 
   /**
@@ -30,7 +33,7 @@ class Alias implements \lang\Value {
    * @return var
    */
   public function __invoke($node, $context, $options) {
-    return [$this->name => $context];
+    return [$this->names[0] => $context]; // FIXME
   }
 
   /**
@@ -40,16 +43,16 @@ class Alias implements \lang\Value {
    * @return int
    */
   public function compareTo($value) {
-    return $value instanceof self ? $this->name <=> $value->name : 1;
+    return $value instanceof self ? Objects::compare($this->names, $value->names) : 1;
   }
 
   /** @return string */
   public function hashCode() {
-    return md5($this->name);
+    return Objects::hashOf($this->name);
   }
 
   /** @return string */
   public function toString() {
-    return nameof($this).'('.$this.')';
+    return nameof($this).'('.implode(' ', $this->names).')';
   }
 }

--- a/src/main/php/com/handlebarsjs/HandlebarsParser.class.php
+++ b/src/main/php/com/handlebarsjs/HandlebarsParser.class.php
@@ -79,10 +79,10 @@ class HandlebarsParser extends AbstractMustacheParser {
             $value= new Constant(null);
           } else if ('.' === $token) {
             $value= new Lookup(null);
-          } else if ('as' === $token) {                     // Aliases (as |...|)
+          } else if ('as' === $token) {                     // Block parameters (as |...|)
             $o= strpos($tag, '|', $o);
             $p= strcspn($tag, '|', $o + 1);
-            $value= new Alias(trim(substr($tag, $o + 1, $p)));
+            $value= new BlockParams(explode(' ', trim(substr($tag, $o + 1, $p))));
             $p++;
           } else if (strspn($token, '-.0123456789') === strlen($token)) {
             $value= new Constant(strstr($token, '.') ? (double)$token : (int)$token);

--- a/src/main/php/com/handlebarsjs/HashContext.class.php
+++ b/src/main/php/com/handlebarsjs/HashContext.class.php
@@ -17,14 +17,14 @@ class HashContext extends DataContext {
    * Constructor
    *
    * @param  com.github.mustache.Context $parent
-   * @param  var $map
+   * @param  [:var]|Generator $iterable
    * @param  ?string $element
    * @param  ?string $index
    */
-  public function __construct(Context $parent, $map, $element= null, $index= null) {
+  public function __construct(Context $parent, $iterable, $element= null, $index= null) {
     parent::__construct(null, $parent);
-    $this->map= $map;
-    $this->last= is_array($map) ? (end($this->map) ? key($this->map) : null) : null; // array_key_last for PHP >= 7.3
+    $this->map= $iterable;
+    $this->last= is_array($iterable) ? (end($this->map) ? key($this->map) : null) : null; // array_key_last for PHP >= 7.3
     $this->element= $element;
     $this->index= $index;
   }

--- a/src/main/php/com/handlebarsjs/HashContext.class.php
+++ b/src/main/php/com/handlebarsjs/HashContext.class.php
@@ -10,6 +10,7 @@ use com\github\mustache\{Context, DataContext};
 class HashContext extends DataContext {
   private $map, $element, $index;
   private $first= true;
+  private $last= null;
   private $key= null;
 
   /**
@@ -23,6 +24,7 @@ class HashContext extends DataContext {
   public function __construct(Context $parent, $map, $element= null, $index= null) {
     parent::__construct(null, $parent);
     $this->map= $map;
+    $this->last= is_array($map) ? (end($this->map) ? key($this->map) : null) : null; // array_key_last for PHP >= 7.3
     $this->element= $element;
     $this->index= $index;
   }
@@ -56,6 +58,8 @@ class HashContext extends DataContext {
       return $this->key;
     } else if ('@first' === $s) {
       return $this->first ? 'true' : null;
+    } else if ('@last' === $s && null !== $this->last) {
+      return $this->key === $this->last ? 'true' : null;
     } else if ($this->element === $s) {
       return $this->variables;
     }

--- a/src/main/php/com/handlebarsjs/HashContext.class.php
+++ b/src/main/php/com/handlebarsjs/HashContext.class.php
@@ -7,52 +7,59 @@ use com\github\mustache\{Context, DataContext};
  *
  * @test  xp://com.handlebarsjs.unittest.EachHelperTest
  */
-class HashContext extends Context {
-  protected $key;
-  protected $first;
-  protected $backing;
+class HashContext extends DataContext {
+  private $map, $element, $index;
+  private $first= true;
+  private $key= null;
 
   /**
    * Constructor
    *
-   * @param  string $key
-   * @param  bool $first
-   * @param  parent $backing
+   * @param  com.github.mustache.Context $parent
+   * @param  var $map
+   * @param  ?string $element
+   * @param  ?string $index
    */
-  public function __construct($key, $first, parent $backing) {
-    parent::__construct($backing->variables, $backing->parent);
-    $this->key= $key;
-    $this->first= $first;
-    $this->backing= $backing;
+  public function __construct(Context $parent, $map, $element= null, $index= null) {
+    parent::__construct(null, $parent);
+    $this->map= $map;
+    $this->element= $element;
+    $this->index= $index;
   }
 
   /**
-   * Returns a context inherited from this context
+   * Writes output
    *
-   * @param  var $result
-   * @return self
+   * @param  com.handlebarsjs.Nodes $fn
+   * @param  io.streams.OutputStream $out
    */
-  public function asContext($result) {
-    return new DataContext($result, $this);
+  public function write($fn, $out) {
+
+    // We modify this context directly while we're going - this way,
+    // we save creating context instances for each element.
+    foreach ($this->map as $this->key => $this->variables) {
+      $fn->write($this, $out);
+      $this->first= false;
+    }
   }
 
   /**
-   * Helper method to retrieve a pointer inside a given data structure
-   * using a given segment. Returns null if there is no such segment.
-   * Called from within the `lookup()` method for every segment in the
-   * variable name.
+   * Looks up segments inside a given collection
    *
-   * @param  var $ptr
-   * @param  string $segment
+   * @param  var $v
+   * @param  string[] $segments
    * @return var
    */
-  protected function pointer($ptr, $segment) {
-    if ('@first' === $segment) {
-      return $this->first ? 'true' : null;
-    } else if ('@key' === $segment) {
+  protected function lookup0($v, $segments) {
+    $s= $segments[0];
+    if ('@key' === $s || $this->index === $s) {
       return $this->key;
-    } else {
-      return $this->backing->pointer($ptr, $segment);
+    } else if ('@first' === $s) {
+      return $this->first ? 'true' : null;
+    } else if ($this->element === $s) {
+      return $this->variables;
     }
+
+    return parent::lookup0($v, $segments);
   }
 }

--- a/src/main/php/com/handlebarsjs/ListContext.class.php
+++ b/src/main/php/com/handlebarsjs/ListContext.class.php
@@ -7,54 +7,60 @@ use com\github\mustache\{Context, DataContext};
  *
  * @test  xp://com.handlebarsjs.unittest.EachHelperTest
  */
-class ListContext extends Context {
-  protected $index;
-  protected $last;
-  protected $backing;
+class ListContext extends DataContext {
+  private $list, $last, $element, $index;
+  private $offset= null;
 
   /**
    * Constructor
    *
-   * @param  int $index
-   * @param  int $size
-   * @param  parent $backing
+   * @param  com.github.mustache.Context $parent
+   * @param  var[] $list
+   * @param  ?string $element
+   * @param  ?string $index
    */
-  public function __construct($index, $size, parent $backing) {
-    parent::__construct($backing->variables, $backing->parent);
+  public function __construct(Context $parent, $list, $element= null, $index= null) {
+    parent::__construct(null, $parent);
+    $this->list= $list;
+    $this->last= sizeof($this->list) - 1;
+    $this->element= $element;
     $this->index= $index;
-    $this->last= $size - 1;
-    $this->backing= $backing;
   }
 
   /**
-   * Returns a context inherited from this context
+   * Writes output
    *
-   * @param  var $result
-   * @return self
+   * @param  com.handlebarsjs.Nodes $fn
+   * @param  io.streams.OutputStream $out
    */
-  public function asContext($result) {
-    return new DataContext($result, $this);
+  public function write($fn, $out) {
+
+    // We modify this context directly while we're going - this way,
+    // we save creating context instances for each element.
+    foreach ($this->list as $this->offset => $this->variables) {
+      $fn->write($this, $out);
+    }
   }
 
   /**
-   * Helper method to retrieve a pointer inside a given data structure
-   * using a given segment. Returns null if there is no such segment.
-   * Called from within the `lookup()` method for every segment in the
-   * variable name.
+   * Looks up segments inside a given collection
    *
-   * @param  var $ptr
-   * @param  string $segment
+   * @param  var $v
+   * @param  string[] $segments
    * @return var
    */
-  protected function pointer($ptr, $segment) {
-    if ('@first' === $segment) {
-      return 0 === $this->index ? 'true' : null;
-    } else if ('@last' === $segment) {
-      return $this->last === $this->index ? 'true' : null;
-    } else if ('@index' === $segment) {
-      return $this->index;
-    } else {
-      return $this->backing->pointer($ptr, $segment);
+  protected function lookup0($v, $segments) {
+    $s= $segments[0];
+    if ('@index' === $s || $this->index === $s) {
+      return $this->offset;
+    } else if ('@first' === $s) {
+      return 0 === $this->offset ? 'true' : null;
+    } else if ('@last' === $s) {
+      return $this->last === $this->offset ? 'true' : null;
+    } else if ($this->element === $s) {
+      return $this->variables;
     }
+
+    return parent::lookup0($v, $segments);
   }
 }

--- a/src/main/php/com/handlebarsjs/WithBlockHelper.class.php
+++ b/src/main/php/com/handlebarsjs/WithBlockHelper.class.php
@@ -6,6 +6,7 @@
  * @test xp://com.handlebarsjs.unittest.WithHelperTest
  */
 class WithBlockHelper extends BlockNode {
+  private $alias;
 
   /**
    * Creates a new with block helper
@@ -18,6 +19,7 @@ class WithBlockHelper extends BlockNode {
    */
   public function __construct($options= [], NodeList $fn= null, NodeList $inverse= null, $start= '{{', $end= '}}') {
     parent::__construct('with', $options, $fn, $inverse, $start, $end);
+    $this->alias= isset($options[1]) ? cast($options[1], BlockParams::class)->names[0] : null;
   }
 
   /**
@@ -28,7 +30,7 @@ class WithBlockHelper extends BlockNode {
    */
   public function write($context, $out) {
     $target= $this->options[0]($this, $context, []);
-    $self= $context->asContext(isset($this->options[1]) ? $this->options[1]($this, $target, []) : $target);
+    $self= $context->asContext($this->alias ? [$this->alias => $target] : $target);
 
     if ($context->isTruthy($target)) {
       $this->fn->write($self, $out);

--- a/src/test/php/com/handlebarsjs/unittest/EachHelperTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/EachHelperTest.class.php
@@ -107,6 +107,14 @@ class EachHelperTest extends HelperTest {
     ));
   }
 
+  #[Test]
+  public function with_hash_properties_and_last() {
+    Assert::equals(': green true: $12.40 ', $this->evaluate(
+      '{{#each item}}{{@last}}: {{.}} {{/each}}',
+      $this->item()
+    ));
+  }
+
   #[Test, Values(['else', '^'])]
   public function else_invoked_for_non_truthy($else) {
     Assert::equals('Default', $this->evaluate('{{#each var}}-{{.}}-{{'.$else.'}}Default{{/each}}', [

--- a/src/test/php/com/handlebarsjs/unittest/EachHelperTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/EachHelperTest.class.php
@@ -180,4 +180,44 @@ class EachHelperTest extends HelperTest {
       ['people' => $f()]
     ));
   }
+
+  #[Test]
+  public function hash_with_as_index_element() {
+    Assert::equals('key: value', $this->evaluate(
+      '{{#each items as |item index|}}{{index}}: {{item.name}}{{/each}}',
+      ['items' => ['key' => 'value']]
+    ));
+  }
+
+  #[Test]
+  public function hash_with_as_element() {
+    Assert::equals('key: value', $this->evaluate(
+      '{{#each items as |item|}}{{@key}}: {{item.name}}{{/each}}',
+      ['items' => ['key' => 'value']]
+    ));
+  }
+
+  #[Test]
+  public function generator_with_as() {
+    Assert::equals('key: value', $this->evaluate(
+      '{{#each items as |item index|}}{{index}}: {{item.name}}{{/each}}',
+      ['items' => (function() { yield 'key' => 'value'; })()]
+    ));
+  }
+
+  #[Test]
+  public function array_with_as_index_element() {
+    Assert::equals('0: value', $this->evaluate(
+      '{{#each items as |item index|}}{{index}}: {{item.name}}{{/each}}',
+      ['items' => ['value']]
+    ));
+  }
+
+  #[Test]
+  public function array_with_as_element() {
+    Assert::equals('0: value', $this->evaluate(
+      '{{#each items as |item|}}{{@index}}: {{item.name}}{{/each}}',
+      ['items' => ['value']]
+    ));
+  }
 }


### PR DESCRIPTION
Example:

```handlebars
<!-- Using block params -->
{{#each items as |item index|}}
  {{index}}: {{item.name}}
{{/each}}

<!-- Equivalent -->
{{#each items}}
  {{@index}}: {{name}}
{{/each}}
```

See handlebars-lang/handlebars.js#906