### PR TITLE
Ensure Handlebars engine uses its own default context

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,11 @@ HandleBars change log
 
 ## ?.?.? / ????-??-??
 
+* Added support for accessing outer iteration via e.g. `../@index` or
+  `../../@key`, see pull request #19
+  (@thekid)
+* Added support for `@root`, implementing feature request #18 - @thekid
+
 ## 6.0.1 / 2021-05-02
 
 * Fixed nested contexts inside `{{#each}}...{{/each}}` - @thekid

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,10 +3,13 @@ HandleBars change log
 
 ## ?.?.? / ????-??-??
 
-* Added support for accessing outer iteration via e.g. `../@index` or
-  `../../@key`, see pull request #19
+* Added support for repeating parent selector `../` to form lookups such
+  as `../../name`, see pull request #19
   (@thekid)
-* Added support for `@root`, implementing feature request #18 - @thekid
+* Added support for accessing outer iteration via e.g. `../@index` or
+  `../@key`, see pull request #19
+  (@thekid)
+* Added support for `@root`, implemented feature request #18 - @thekid
 
 ## 6.0.1 / 2021-05-02
 

--- a/src/main/php/com/handlebarsjs/DefaultContext.class.php
+++ b/src/main/php/com/handlebarsjs/DefaultContext.class.php
@@ -1,0 +1,80 @@
+<?php namespace com\handlebarsjs;
+
+use com\github\mustache\DataContext;
+
+/**
+ * Default context for handlebars. Supports `@root` and `this` in addition
+ * to `./` and `../` notations from Mustache.
+ *
+ * @test  xp://com.handlebarsjs.unittest.ExecutionTest
+ */
+class DefaultContext extends DataContext {
+
+  /**
+   * Lookups up paths using the given segments
+   *
+   * @param  string[] $segments
+   * @return var
+   */
+  public function path($segments) {
+    $v= $this->variables;
+    foreach ($segments as $segment) {
+      if ($v !== null) $v= $this->pointer($v, $segment);
+    }
+    return $v;
+  }
+
+  /**
+   * Looks up variable:
+   *
+   * - (null)
+   * - person.name
+   * - ./name
+   * - ../name (and ../@index but not ../@root)
+   * - this (but no special meaning for ./this and ../this)
+   * - @root
+   *
+   * @param  ?string $name Name including optional segments, separated by dots.
+   * @param  bool $helpers Whether to check helpers
+   * @return var the variable, or null if nothing is found
+   */
+  public final function lookup($name, $helpers= true) {
+    if (null === $name) {
+      $segments= [];
+      $v= $this->variables;
+    } else if ('.' !== $name[0]) {
+      $segments= explode('.', $name);
+      if ('this' === $segments[0]) {
+        $v= $this->path(array_slice($segments, 1));
+      } else if ('@root' === $segments[0]) {
+        $context= $this;
+        while (null !== $context->parent) {
+          $context= $context->parent;
+        }
+        return $context->path(array_slice($segments, 1));
+      } else {
+        $context= $this;
+        do {
+          $v= $context->path($segments);
+        } while (null === $v && $context= $context->parent);
+      }
+    } else if (0 === strncmp('../', $name, 3)) {  // Explicitely selected: parent
+      $segments= explode('.', substr($name, 3));
+      $v= $this->parent ? $this->parent->path($segments) : null;
+    } else if (0 === strncmp('./', $name, 2)) {   // Explicitely selected: self
+      $segments= explode('.', substr($name, 2));
+      $v= $this->path($segments);
+    } else {
+      return null;                                // Illegal name
+    }
+
+    // Check helpers
+    if (null === $v && $helpers) {
+      $v= $this->engine->helpers;
+      foreach ($segments as $segment) {
+        if ($v !== null) $v= $this->helper($v, $segment);
+      }
+    }
+    return $v;
+  }
+}

--- a/src/main/php/com/handlebarsjs/DefaultContext.class.php
+++ b/src/main/php/com/handlebarsjs/DefaultContext.class.php
@@ -31,6 +31,7 @@ class DefaultContext extends DataContext {
    * - person.name
    * - ./name
    * - ../name (and ../@index but not ../@root)
+   * - ../../name
    * - this (but no special meaning for ./this and ../this)
    * - @root
    *
@@ -58,14 +59,18 @@ class DefaultContext extends DataContext {
           $v= $context->path($segments);
         } while (null === $v && $context= $context->parent);
       }
-    } else if (0 === strncmp('../', $name, 3)) {  // Explicitely selected: parent
-      $segments= explode('.', substr($name, 3));
-      $v= $this->parent ? $this->parent->path($segments) : null;
-    } else if (0 === strncmp('./', $name, 2)) {   // Explicitely selected: self
+    } else if (0 === strncmp('./', $name, 2)) {
       $segments= explode('.', substr($name, 2));
       $v= $this->path($segments);
     } else {
-      return null;                                // Illegal name
+      $context= $this;
+      $offset= 0;
+      while (0 === substr_compare($name, '../', $offset, 3)) {
+        $context= $context->parent;
+        $offset+= 3;
+      }
+      $segments= explode('.', substr($name, $offset));
+      $v= $context ? $context->path($segments) : null;
     }
 
     // Check helpers

--- a/src/main/php/com/handlebarsjs/HandlebarsEngine.class.php
+++ b/src/main/php/com/handlebarsjs/HandlebarsEngine.class.php
@@ -29,14 +29,6 @@ class HandlebarsEngine {
 
   static function __static() {
     self::$builtin= [
-      'this'    => function($node, $context, $options) {
-        $variable= $context->lookup(null);
-        if ($context->isHash($variable) || $context->isList($variable)) {
-          return current($context->asTraversable($variable));
-        } else {
-          return $variable;
-        }
-      },
       'lookup'  => function($node, $context, $options) {
         return $options[0][$options[1]] ?? null;
       },
@@ -174,7 +166,7 @@ class HandlebarsEngine {
    * @return string The rendered output
    */
   public function evaluate(Template $template, $arg) {
-    $c= $arg instanceof Context ? $arg : new DataContext($arg);
+    $c= $arg instanceof Context ? new DefaultContext($arg->variables, $arg->parent) : new DefaultContext($arg);
     return $template->evaluate($c->withEngine($this));
   }
 
@@ -187,7 +179,7 @@ class HandlebarsEngine {
    * @return void
    */
   public function write(Template $template, $arg, $out) {
-    $c= $arg instanceof Context ? $arg : new DataContext($arg);
+    $c= $arg instanceof Context ? new DefaultContext($arg->variables, $arg->parent) : new DefaultContext($arg);
     $template->write($c->withEngine($this), $out);
   }
 

--- a/src/main/php/com/handlebarsjs/HashContext.class.php
+++ b/src/main/php/com/handlebarsjs/HashContext.class.php
@@ -1,13 +1,13 @@
 <?php namespace com\handlebarsjs;
 
-use com\github\mustache\{Context, DataContext};
+use com\github\mustache\Context;
 
 /**
  * Hash context for the `each` helper.
  *
  * @test  xp://com.handlebarsjs.unittest.EachHelperTest
  */
-class HashContext extends DataContext {
+class HashContext extends DefaultContext {
   private $map, $element, $index;
   private $first= true;
   private $last= null;
@@ -36,7 +36,7 @@ class HashContext extends DataContext {
    * @return self
    */
   public function asContext($result) {
-    return new DataContext($result, $this);
+    return new DefaultContext($result, $this);
   }
 
   /**
@@ -55,25 +55,17 @@ class HashContext extends DataContext {
     }
   }
 
-  /**
-   * Looks up segments inside a given collection
-   *
-   * @param  var $v
-   * @param  string[] $segments
-   * @return var
-   */
-  protected function lookup0($v, $segments) {
-    $s= $segments[0];
-    if ('@key' === $s || $this->index === $s) {
-      return $this->key;
-    } else if ('@first' === $s) {
-      return $this->first ? 'true' : null;
-    } else if ('@last' === $s && null !== $this->last) {
-      return $this->key === $this->last ? 'true' : null;
-    } else if ($this->element === $s) {
+  public function path($segments) {
+    if (null === ($start= $segments[0] ?? null) || $this->element === $start) {
       return $this->variables;
+    } else if ('@key' === $start || $this->index === $start) {
+      return $this->key;
+    } else if ('@first' === $start) {
+      return $this->first ? 'true' : null;
+    } else if ('@last' === $start && null !== $this->last) {
+      return $this->key === $this->last ? 'true' : null;
+    } else {
+      return parent::path($segments);
     }
-
-    return parent::lookup0($v, $segments);
   }
 }

--- a/src/main/php/com/handlebarsjs/HashContext.class.php
+++ b/src/main/php/com/handlebarsjs/HashContext.class.php
@@ -1,7 +1,5 @@
 <?php namespace com\handlebarsjs;
 
-use com\github\mustache\Context;
-
 /**
  * Hash context for the `each` helper.
  *
@@ -16,12 +14,12 @@ class HashContext extends DefaultContext {
   /**
    * Constructor
    *
-   * @param  com.github.mustache.Context $parent
+   * @param  parent $parent
    * @param  [:var]|Generator $iterable
    * @param  ?string $element
    * @param  ?string $index
    */
-  public function __construct(Context $parent, $iterable, $element= null, $index= null) {
+  public function __construct(parent $parent, $iterable, $element= null, $index= null) {
     parent::__construct(null, $parent);
     $this->map= $iterable;
     $this->last= is_array($iterable) ? (end($this->map) ? key($this->map) : null) : null; // array_key_last for PHP >= 7.3
@@ -36,7 +34,7 @@ class HashContext extends DefaultContext {
    * @return self
    */
   public function asContext($result) {
-    return new DefaultContext($result, $this);
+    return new parent($result, $this);
   }
 
   /**

--- a/src/main/php/com/handlebarsjs/ListContext.class.php
+++ b/src/main/php/com/handlebarsjs/ListContext.class.php
@@ -1,13 +1,13 @@
 <?php namespace com\handlebarsjs;
 
-use com\github\mustache\{Context, DataContext};
+use com\github\mustache\Context;
 
 /**
  * List context for the `each` helper.
  *
  * @test  xp://com.handlebarsjs.unittest.EachHelperTest
  */
-class ListContext extends DataContext {
+class ListContext extends DefaultContext {
   private $list, $last, $element, $index;
   private $offset= null;
 
@@ -34,7 +34,7 @@ class ListContext extends DataContext {
    * @return self
    */
   public function asContext($result) {
-    return new DataContext($result, $this);
+    return new DefaultContext($result, $this);
   }
 
   /**
@@ -52,25 +52,17 @@ class ListContext extends DataContext {
     }
   }
 
-  /**
-   * Looks up segments inside a given collection
-   *
-   * @param  var $v
-   * @param  string[] $segments
-   * @return var
-   */
-  protected function lookup0($v, $segments) {
-    $s= $segments[0];
-    if ('@index' === $s || $this->index === $s) {
-      return $this->offset;
-    } else if ('@first' === $s) {
-      return 0 === $this->offset ? 'true' : null;
-    } else if ('@last' === $s) {
-      return $this->last === $this->offset ? 'true' : null;
-    } else if ($this->element === $s) {
+  public function path($segments) {
+    if (null === ($start= $segments[0] ?? null) || $this->element === $start) {
       return $this->variables;
+    } else if ('@index' === $start || $this->index === $start) {
+      return $this->offset;
+    } else if ('@first' === $start) {
+      return 0 === $this->offset ? 'true' : null;
+    } else if ('@last' === $start) {
+      return $this->last === $this->offset ? 'true' : null;
+    } else {
+      return parent::path($segments);
     }
-
-    return parent::lookup0($v, $segments);
   }
 }

--- a/src/main/php/com/handlebarsjs/ListContext.class.php
+++ b/src/main/php/com/handlebarsjs/ListContext.class.php
@@ -1,7 +1,5 @@
 <?php namespace com\handlebarsjs;
 
-use com\github\mustache\Context;
-
 /**
  * List context for the `each` helper.
  *
@@ -14,12 +12,12 @@ class ListContext extends DefaultContext {
   /**
    * Constructor
    *
-   * @param  com.github.mustache.Context $parent
+   * @param  parent $parent
    * @param  var[] $list
    * @param  ?string $element
    * @param  ?string $index
    */
-  public function __construct(Context $parent, $list, $element= null, $index= null) {
+  public function __construct(parent $parent, $list, $element= null, $index= null) {
     parent::__construct(null, $parent);
     $this->list= $list;
     $this->last= sizeof($this->list) - 1;
@@ -34,7 +32,7 @@ class ListContext extends DefaultContext {
    * @return self
    */
   public function asContext($result) {
-    return new DefaultContext($result, $this);
+    return new parent($result, $this);
   }
 
   /**

--- a/src/test/php/com/handlebarsjs/unittest/EachHelperTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/EachHelperTest.class.php
@@ -136,6 +136,30 @@ class EachHelperTest extends HelperTest {
   }
 
   #[Test]
+  public function nested_each_with_this_atvariable() {
+    Assert::equals('0:a,1:ä,2:á,3:à, 0:b, 0:c,1:ç, ', $this->evaluate(
+      '{{#each .}}{{#each .}}{{@index}}:{{.}},{{/each}} {{/each}}',
+      [
+        'a' => ['a', 'ä', 'á', 'à'],
+        'b' => ['b'],
+        'c' => ['c', 'ç']
+      ]
+    ));
+  }
+
+  #[Test]
+  public function nested_each_with_parent_atvariable() {
+    Assert::equals('a:a,a:ä,a:á,a:à, b:b, c:c,c:ç, ', $this->evaluate(
+      '{{#each .}}{{#each .}}{{../@key}}:{{.}},{{/each}} {{/each}}',
+      [
+        'a' => ['a', 'ä', 'á', 'à'],
+        'b' => ['b'],
+        'c' => ['c', 'ç']
+      ]
+    ));
+  }
+
+  #[Test]
   public function nested_each_with_hashes() {
     Assert::equals('timm :crown: :snowman:', $this->evaluate(
       '{{#each player}}{{name}}{{#each badges}} :{{name}}:{{/each}}{{/each}}',

--- a/src/test/php/com/handlebarsjs/unittest/ExecutionTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/ExecutionTest.class.php
@@ -19,9 +19,27 @@ class ExecutionTest {
 
   #[Test]
   public function this_reference_resolves_to_current_scope() {
+    Assert::equals('Test', $this->evaluate('{{this.name}}', ['name' => 'Test']));
+  }
+
+  #[Test]
+  public function this_has_no_special_meaning_in_path() {
+    Assert::equals('Test', $this->evaluate('{{./this}}', ['this' => 'Test']));
+  }
+
+  #[Test]
+  public function root_reference() {
+    Assert::equals('Test', $this->evaluate('{{@root.name.en}}', ['name' => ['en' => 'Test']]));
+  }
+
+  #[Test]
+  public function root_reference_inside_nested() {
     Assert::equals(
-      'Test',
-      $this->evaluate('{{this.name}}', ['name' => 'Test'])
+      'A Test',
+      $this->evaluate('{{#each iteration}}{{#with fixture}}{{article}} {{@root.name.en}}{{/with}}{{/each}}', [
+        'name' => ['en' => 'Test'],
+        'iteration' => [['fixture' => ['article' => 'A']]]
+      ])
     );
   }
 

--- a/src/test/php/com/handlebarsjs/unittest/ExecutionTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/ExecutionTest.class.php
@@ -46,10 +46,13 @@ class ExecutionTest {
   #[Test]
   public function dot_references_resolving_in_scopes() {
     Assert::equals(
-      'TestPerson',
-      $this->evaluate('{{#person}}{{../name}}{{./name}}{{/person}}', [
-        'name'   => 'Test',
-        'person' => ['name' => 'Person']
+      'ATestPerson',
+      $this->evaluate('{{#nested}}{{#person}}{{../../name}}{{../name}}{{./name}}{{/person}}{{/nested}}', [
+        'name'   => 'A',
+        'nested' => [
+          'name'   => 'Test',
+          'person' => ['name' => 'Person']
+        ]
       ])
     );
   }

--- a/src/test/php/com/handlebarsjs/unittest/WebsiteExamplesTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/WebsiteExamplesTest.class.php
@@ -190,9 +190,9 @@ class WebsiteExamplesTest {
         "  {{/each}}\n".
         "</ul>",
         ['people' => [
-          ['Yehuda Katz'],
-          ['Carl Lerche'],
-          ['Alan Johnson']
+          'Yehuda Katz',
+          'Carl Lerche',
+          'Alan Johnson'
         ]]
       )
     );


### PR DESCRIPTION
This way, we have the control we need over its lookup rules, including `this` and `@root` (see #18 ). Also adds support for `../@index` to access outer iteration context as well as repeated `../`, e.g. `../../name`.