### PR TITLE
Make it possible to exchange the parser

### DIFF
--- a/src/main/php/com/handlebarsjs/HandlebarsEngine.class.php
+++ b/src/main/php/com/handlebarsjs/HandlebarsEngine.class.php
@@ -39,11 +39,14 @@ class HandlebarsEngine {
   }
 
   /** Create new instance and initialize builtin helpers */
-  public function __construct() {
+  public function __construct(HandlebarsParser $parser= null) {
+    $this->parser= $parser ?? new HandlebarsParser();
     $this->templates= new Templates();
-    $this->parser= new HandlebarsParser();
     $this->helpers= self::$builtin;
   }
+
+  /** @return com.handlebarsjs.HandlebarsParser */
+  public function parser() { return $this->parser; }
 
   /** @return com.github.mustache.TemplateLoader */
   public function templates() { return $this->templates; }

--- a/src/main/php/com/handlebarsjs/HandlebarsParser.class.php
+++ b/src/main/php/com/handlebarsjs/HandlebarsParser.class.php
@@ -236,7 +236,7 @@ class HandlebarsParser extends AbstractMustacheParser {
   /**
    * Parse a template
    *
-   * @param  string $template The template as a string
+   * @param  text.Tokenizer $tokens
    * @param  string $start Initial start tag, defaults to "{{"
    * @param  string $end Initial end tag, defaults to "}}"
    * @param  string $indent What to prefix before each line

--- a/src/test/php/com/handlebarsjs/unittest/EngineTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/EngineTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\handlebarsjs\unittest;
 
-use com\handlebarsjs\HandlebarsEngine;
+use com\handlebarsjs\{HandlebarsEngine, HandlebarsParser};
 use io\streams\MemoryOutputStream;
 use lang\IllegalArgumentException;
 use unittest\{Assert, Expect, Test};
@@ -58,5 +58,13 @@ class EngineTest {
     $engine->write($engine->compile('Hello {{name}}'), ['name' => 'World'], $out);
 
     Assert::equals('Hello World', $out->getBytes());
+  }
+
+  #[Test]
+  public function exchange_parser() {
+    $engine= new HandlebarsEngine(new class() extends HandlebarsParser {
+      public function version() { return '1.0.0'; }
+    });
+    Assert::equals('1.0.0', $engine->parser()->version());
   }
 }


### PR DESCRIPTION
Example:

```php
use com\handlebarsjs\{HandlebarsEngine, HandlebarsParser};

new HandlebarsEngine(new class() extends HandlebarsParser {
  // TBI
});
```