### PR TITLE
Add support for "../."

### DIFF
--- a/src/main/php/com/handlebarsjs/DefaultContext.class.php
+++ b/src/main/php/com/handlebarsjs/DefaultContext.class.php
@@ -81,8 +81,14 @@ class DefaultContext extends DataContext {
         $context= $context->parent;
         $offset+= 3;
       }
-      $segments= explode('.', substr($name, $offset));
-      $v= $context ? $context->path($segments) : null;
+      $path= substr($name, $offset);
+      if ('.' === $path) {
+        $segments= [];
+        $v= $context ? $context->variables : null;
+      } else {
+        $segments= explode('.', $path);
+        $v= $context ? $context->path(explode('.', $path)) : null;
+      }
     }
 
     // Check helpers

--- a/src/test/php/com/handlebarsjs/unittest/LookupHelperTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/LookupHelperTest.class.php
@@ -25,4 +25,15 @@ class LookupHelperTest extends HelperTest {
   public function lookup_non_existant($expr) {
     Assert::equals('', $this->evaluate($expr, []));
   }
+
+  #[Test]
+  public function parent_dot() {
+    Assert::equals('php=PHP', $this->evaluate(
+      '{{#each extensions}}{{#with (lookup names .)}}{{../.}}={{.}}{{/with}}{{/each}}',
+      [
+        'names'      => ['php' => 'PHP'],
+        'extensions' => ['php']
+      ]
+    ));
+  }
 }

--- a/src/test/php/com/handlebarsjs/unittest/LookupHelperTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/LookupHelperTest.class.php
@@ -28,12 +28,12 @@ class LookupHelperTest extends HelperTest {
 
   #[Test]
   public function parent_dot() {
-    Assert::equals('php=PHP', $this->evaluate(
-      '{{#each extensions}}{{#with (lookup names .)}}{{../.}}={{.}}{{/with}}{{/each}}',
-      [
-        'names'      => ['php' => 'PHP'],
-        'extensions' => ['php']
-      ]
-    ));
+    Assert::equals(
+      'php=PHP',
+      $this->evaluate(
+        '{{#each extensions}}{{#with (lookup names .)}}{{../.}}={{.}}{{/with}}{{/each}}',
+        ['names' => ['php' => 'PHP'], 'extensions' => ['php']]
+      )
+    );
   }
 }

--- a/src/test/php/com/handlebarsjs/unittest/WithHelperTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/WithHelperTest.class.php
@@ -19,6 +19,14 @@ class WithHelperTest extends HelperTest {
     ));
   }
 
+  #[Test]
+  public function can_access_parent_context() {
+    Assert::equals('PHP: 9870000000 results @ Google', $this->evaluate(
+      '{{#with results}}PHP: {{php}} results @ {{../engine}}{{/with}}',
+      ['engine' => 'Google', 'results' => ['php' => 9870000000, 'javascript' => 6380000000]]
+    ));
+  }
+
   #[Test, Values(['else', '^'])]
   public function else_invoked_for_non_truthy($else) {
     Assert::equals('Default', $this->evaluate('{{#with var}}-{{.}}-{{'.$else.'}}Default{{/with}}', [


### PR DESCRIPTION
Used e.g. in conjunction with `with` and `lookup`.