### PR TITLE
Give helpers precedence over input properties

### DIFF
--- a/src/test/php/com/handlebarsjs/unittest/ExecutionTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/ExecutionTest.class.php
@@ -16,8 +16,8 @@ class ExecutionTest {
   protected function evaluate($template, $variables, $templates= ['test' => 'Partial']) {
     return (new HandlebarsEngine())
       ->withTemplates(new InMemory($templates))
-      ->withHelper('date', function($node, $context, $options) { return date('Y-m-d', $options[0] ?? null); })
-      ->withHelper('time', ['short' => ['24' => function($node, $context, $options) { return date('H:i', $options[0] ?? null); }]])
+      ->withHelper('date', function($node, $context, $options) { return date('Y-m-d', $options[0] ?? time()); })
+      ->withHelper('time', ['short' => ['24' => function($node, $context, $options) { return date('H:i', $options[0] ?? time()); }]])
       ->render($template, $variables)
     ;
   }


### PR DESCRIPTION
> If a helper is registered by the same name as a property of an input object, the helper has priority over the input property. If you want to resolve the input property instead, you can prefix its name with `./` or `this.`

See https://handlebarsjs.com/guide/expressions.html#disambiguating-helpers-calls-and-property-lookup

⚠️ This pull request is a fix, but it's also a BC break for templates - we'll release this as a major version!