### PR TITLE
Add support for literal segments, e.g. `array.[0].[item-class]`

### DIFF
--- a/src/main/php/com/handlebarsjs/DefaultContext.class.php
+++ b/src/main/php/com/handlebarsjs/DefaultContext.class.php
@@ -62,7 +62,7 @@ class DefaultContext extends DataContext {
           }
 
           $r[]= $q.substr($input, $o, $s);
-          $o+= $s + 4;
+          $o+= $s + 3;
         } else {
           $s= strcspn($input, ']', $o);
           $r[]= substr($input, $o + 1, $s - 1);

--- a/src/main/php/com/handlebarsjs/DefaultContext.class.php
+++ b/src/main/php/com/handlebarsjs/DefaultContext.class.php
@@ -13,14 +13,12 @@ class DefaultContext extends DataContext {
   /**
    * Lookups up paths using the given segments, including literal segments.
    *
-   * @see    https://handlebarsjs.com/guide/expressions.html#literal-segments
    * @param  string[] $segments
    * @return var
    */
   public function path($segments) {
     $v= $this->variables;
     foreach ($segments as $segment) {
-      if ('[' === $segment[0]) $segment= trim($segment, '[]"\'');
       if (null === ($v= $this->pointer($v, $segment))) return null;
     }
     return $v;
@@ -36,6 +34,48 @@ class DefaultContext extends DataContext {
    */
   public final function newInstance($result, Context $parent= null) {
     return new self($result, $parent ?: $this);
+  }
+
+  /**
+   * Parse input into segments. Handles literal segments including quoted
+   * strings, e.g. `input.["item-class"]`.
+   *
+   * @see    https://handlebarsjs.com/guide/expressions.html#literal-segments
+   * @param  string $input
+   * @return string[]
+   */
+  private function segments($input) {
+    $r= [];
+    $o= 0;
+    while ($o < strlen($input)) {
+      if ('[' === $input[$o]) {
+        $c= $input[$o + 1] ?? null;
+        if ('"' === $c || "'" === $c) {
+          $o+= 2;
+          $q= '';
+
+          quoted: $s= strcspn($input, '\\'.$c, $o);
+          $q.= substr($input, $o, $s);
+          if ('\\' === $input[$o + $s] ?? null) {
+            $q.= $c;
+            $o+= $s + 2;
+            goto quoted;
+          }
+
+          $r[]= $q;
+          $o+= $s + 4;
+        } else {
+          $s= strcspn($input, ']', $o);
+          $r[]= substr($input, $o + 1, $s - 1);
+          $o+= $s + 2;
+        }
+      } else {
+        $s= strcspn($input, '.', $o);
+        $r[]= substr($input, $o, $s);
+        $o+= $s + 1;
+      }
+    }
+    return $r;
   }
 
   /**
@@ -58,7 +98,7 @@ class DefaultContext extends DataContext {
     if (null === $name) {
       return $this->variables;
     } else if ('.' !== $name[0]) {
-      $segments= explode('.', $name);
+      $segments= $this->segments($name);
       if ('this' === $segments[0]) {
         return $this->path(array_slice($segments, 1));
       } else if ('@root' === $segments[0]) {

--- a/src/main/php/com/handlebarsjs/DefaultContext.class.php
+++ b/src/main/php/com/handlebarsjs/DefaultContext.class.php
@@ -11,14 +11,16 @@ use com\github\mustache\{Context, DataContext};
 class DefaultContext extends DataContext {
 
   /**
-   * Lookups up paths using the given segments
+   * Lookups up paths using the given segments, including literal segments.
    *
+   * @see    https://handlebarsjs.com/guide/expressions.html#literal-segments
    * @param  string[] $segments
    * @return var
    */
   public function path($segments) {
     $v= $this->variables;
     foreach ($segments as $segment) {
+      if ('[' === $segment[0]) $segment= trim($segment, '[]"\'');
       if (null === ($v= $this->pointer($v, $segment))) return null;
     }
     return $v;

--- a/src/main/php/com/handlebarsjs/DefaultContext.class.php
+++ b/src/main/php/com/handlebarsjs/DefaultContext.class.php
@@ -54,15 +54,14 @@ class DefaultContext extends DataContext {
           $o+= 2;
           $q= '';
 
-          quoted: $s= strcspn($input, '\\'.$c, $o);
-          $q.= substr($input, $o, $s);
-          if ('\\' === $input[$o + $s] ?? null) {
-            $q.= $c;
-            $o+= $s + 2;
+          quoted: $s= strcspn($input, $c, $o);
+          if ('\\' === $input[$o + $s - 1] ?? null) {
+            $q.= substr($input, $o, $s - 1).$c;
+            $o+= $s + 1;
             goto quoted;
           }
 
-          $r[]= $q;
+          $r[]= $q.substr($input, $o, $s);
           $o+= $s + 4;
         } else {
           $s= strcspn($input, ']', $o);

--- a/src/main/php/com/handlebarsjs/DefaultContext.class.php
+++ b/src/main/php/com/handlebarsjs/DefaultContext.class.php
@@ -130,7 +130,7 @@ class DefaultContext extends DataContext {
       }
 
       $path= substr($name, $offset);
-      return '.' === $path ? $context->variables : $context->path(explode('.', $path));
+      return '.' === $path ? $context->variables : $context->path($this->segments($path));
     }
   }
 }

--- a/src/test/php/com/handlebarsjs/unittest/ExecutionTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/ExecutionTest.class.php
@@ -68,6 +68,21 @@ class ExecutionTest {
     Assert::equals('Test', $this->evaluate($expression, ['item-class' => 'Test']));
   }
 
+  #[Test, Values(['{{[]}}', '{{[""]}}', "{{['']}}"])]
+  public function empty_literal_path($expression) {
+    Assert::equals('Test', $this->evaluate($expression, ['' => 'Test']));
+  }
+
+  #[Test, Values(['{{[item.class]}}', '{{["item.class"]}}', "{{['item.class']}}"])]
+  public function literal_path_with_dot($expression) {
+    Assert::equals('Test', $this->evaluate($expression, ['item.class' => 'Test']));
+  }
+
+  #[Test, Values(['{{["item[\\"class\\"]"]}}', "{{['item[\"class\"]']}}"])]
+  public function literal_path_with_braces_and_quotes($expression) {
+    Assert::equals('Test', $this->evaluate($expression, ['item["class"]' => 'Test']));
+  }
+
   #[Test, Values(['{{array.[0].[item-class]}}', '{{array.[0].["item-class"]}}', "{{array.[0].['item-class']}}"])]
   public function literal_segments($expression) {
     Assert::equals('Test', $this->evaluate($expression, ['array' => [['item-class' => 'Test']]]));

--- a/src/test/php/com/handlebarsjs/unittest/ExecutionTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/ExecutionTest.class.php
@@ -78,14 +78,14 @@ class ExecutionTest {
     Assert::equals('Test', $this->evaluate($expression, ['item.class' => 'Test']));
   }
 
-  #[Test, Values(['{{["item[\\"class\\"]"]}}', "{{['item[\"class\"]']}}"])]
+  #[Test, Values(['{{["item[\\"class\\"]"].en}}', "{{['item[\"class\"]'].en}}"])]
   public function literal_path_with_braces_and_quotes($expression) {
-    Assert::equals('Test', $this->evaluate($expression, ['item["class"]' => 'Test']));
+    Assert::equals('Test', $this->evaluate($expression, ['item["class"]' => ['en' => 'Test']]));
   }
 
-  #[Test, Values(['{{array.[0].[item-class]}}', '{{array.[0].["item-class"]}}', "{{array.[0].['item-class']}}"])]
+  #[Test, Values(['{{array.[0].[item-class].en}}', '{{array.[0].["item-class"].en}}', "{{array.[0].['item-class'].en}}"])]
   public function literal_segments($expression) {
-    Assert::equals('Test', $this->evaluate($expression, ['array' => [['item-class' => 'Test']]]));
+    Assert::equals('Test', $this->evaluate($expression, ['array' => [['item-class' => ['en' => 'Test']]]]));
   }
 
   #[Test]

--- a/src/test/php/com/handlebarsjs/unittest/ExecutionTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/ExecutionTest.class.php
@@ -2,7 +2,7 @@
 
 use com\github\mustache\{InMemory, TemplateNotFoundException};
 use com\handlebarsjs\HandlebarsEngine;
-use unittest\{Assert, Expect, Test};
+use unittest\{Assert, Expect, Test, Values};
 
 class ExecutionTest {
 
@@ -61,6 +61,16 @@ class ExecutionTest {
       date('H:i').' now now',
       $this->evaluate('{{time.short.24}} {{./time.short.24}} {{this.time.short.24}}', $context)
     );
+  }
+
+  #[Test, Values(['{{[item-class]}}', '{{["item-class"]}}', "{{['item-class']}}"])]
+  public function literal_path($expression) {
+    Assert::equals('Test', $this->evaluate($expression, ['item-class' => 'Test']));
+  }
+
+  #[Test, Values(['{{array.[0].[item-class]}}', '{{array.[0].["item-class"]}}', "{{array.[0].['item-class']}}"])]
+  public function literal_segments($expression) {
+    Assert::equals('Test', $this->evaluate($expression, ['array' => [['item-class' => 'Test']]]));
   }
 
   #[Test]

--- a/src/test/php/com/handlebarsjs/unittest/ExecutionTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/ExecutionTest.class.php
@@ -88,6 +88,11 @@ class ExecutionTest {
     Assert::equals('Test', $this->evaluate($expression, ['array' => [['item-class' => ['en' => 'Test']]]]));
   }
 
+  #[Test, Values(['{{../[item.class]}}', '{{../["item.class"]}}', "{{../['item.class']}}"])]
+  public function literal_segments_after_parent_path($expression) {
+    Assert::equals('Test', $this->evaluate('{{#with a}}'.$expression.'{{/with}}', ['item.class' => 'Test', 'a' => true]));
+  }
+
   #[Test]
   public function partial_inside_each() {
     Assert::equals('Test #1', $this->evaluate(


### PR DESCRIPTION
To be able to access array keys including `[`, `]`, `"` and `'`.

See https://handlebarsjs.com/guide/expressions.html#literal-segments