### PR TITLE
Allow registering functions in BlockHelper

### DIFF
--- a/src/main/php/com/handlebarsjs/HandlebarsParser.class.php
+++ b/src/main/php/com/handlebarsjs/HandlebarsParser.class.php
@@ -109,11 +109,14 @@ class HandlebarsParser extends AbstractMustacheParser {
    */
   protected function initialize() {
     $this->blocks= new BlockHelpers([
-      'if'     => IfBlockHelper::class,
-      'unless' => UnlessBlockHelper::class,
-      'with'   => WithBlockHelper::class,
-      'each'   => EachBlockHelper::class,
-      '>'      => PartialBlockHelper::class,
+      'if'      => IfBlockHelper::class,
+      'unless'  => UnlessBlockHelper::class,
+      'with'    => WithBlockHelper::class,
+      'each'    => EachBlockHelper::class,
+      '>'       => PartialBlockHelper::class,
+      '*inline' => function($options, $state) {
+        return new BlockNode('inline', [], $state->parents[0]->declare($options[0] ?? null));
+      }
     ]);
 
     // Sections


### PR DESCRIPTION
...and migrate `*inline` handling. This way, we get rid of the hardcoded `if ('*inline' === $name)` and can register other block helper creation functions.

## Example

```php
// Fragments are instantly-invoked inline partials
$this->blocks->register('*fragment', function($options, $state) {
  $name= $options[0] instanceof Quoted ? $options[0]->chars : $options[0];
  $state->target->add(new PartialBlockHelper([$name]));
  return new BlockNode('fragment', [], $state->parents[0]->declare($name));
});
```