### PR TITLE
Implement inverse blocks

### DIFF
--- a/src/main/php/com/handlebarsjs/HandlebarsParser.class.php
+++ b/src/main/php/com/handlebarsjs/HandlebarsParser.class.php
@@ -9,7 +9,6 @@ use com\github\mustache\{
   TemplateFormatException,
   ParseState
 };
-use lang\MethodNotImplementedException;
 use text\Tokenizer;
 
 /**
@@ -191,13 +190,17 @@ class HandlebarsParser extends AbstractMustacheParser {
     });
 
     // ^ is either an else by its own, or a negated block
-    $this->withHandler('^', true, function($tag, $state) {
-      if ('^' === trim($tag)) {
+    $this->withHandler('^', true, function($tag, $state, $parse) {
+      $tag= trim($tag);
+      if ('^' === $tag) {
         $block= cast($state->parents[sizeof($state->parents) - 1], BlockNode::class);
         $state->target= $block->inverse();
-        return;
+      } else {
+        $state->parents[]= $state->target;
+        $block= new InverseOf($this->blocks->newInstance($parse->options(substr($tag, 1)), $state));
+        $state->target= $block->fn();
+        $state->parents[]= $block;
       }
-      throw new MethodNotImplementedException('^blocks not yet implemented');
     });
 
     // Default

--- a/src/main/php/com/handlebarsjs/InverseOf.class.php
+++ b/src/main/php/com/handlebarsjs/InverseOf.class.php
@@ -1,0 +1,17 @@
+<?php namespace com\handlebarsjs;
+
+/** @test com.handlebarsjs.unittest.InverseOfTest */
+class InverseOf extends BlockNode {
+
+  /** Creates the inverse of a given block */
+  public function __construct(parent $block) {
+    parent::__construct(
+      $block->name,
+      $block->options,
+      /* fn: */ $block->inverse,
+      /* inverse: */ $block->fn,
+      $block->start,
+      $block->end
+    );
+  }
+}

--- a/src/test/php/com/handlebarsjs/unittest/InverseOfTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/InverseOfTest.class.php
@@ -4,8 +4,16 @@ use test\{Assert, Test, Values};
 
 class InverseOfTest extends HelperTest {
 
-  #[Test, Values([[[], 'no people'], [['A', 'B'], 'AB']])]
+  #[Test, Values([[null, 'Guest'], [['name' => 'Test'], 'User Test']])]
   public function inverse_section($input, $outcome) {
+    Assert::equals($outcome, $this->evaluate(
+      '{{#person}}User {{name}}{{/person}}{{^person}}Guest{{/person}}',
+      ['person' => $input]
+    ));
+  }
+
+  #[Test, Values([[[], 'no people'], [['A', 'B'], 'AB']])]
+  public function inverse_iterator($input, $outcome) {
     Assert::equals($outcome, $this->evaluate(
       '{{#people}}{{this}}{{/people}}{{^people}}no people{{/people}}',
       ['people' => $input]
@@ -13,7 +21,7 @@ class InverseOfTest extends HelperTest {
   }
 
   #[Test, Values([[[], 'no people'], [['A', 'B'], 'AB']])]
-  public function inverse_section_with_else($input, $outcome) {
+  public function inverse_iterator_with_else($input, $outcome) {
     Assert::equals($outcome, $this->evaluate(
       '{{#people}}{{this}}{{else}}no people{{/people}}',
       ['people' => $input]
@@ -21,7 +29,7 @@ class InverseOfTest extends HelperTest {
   }
 
   #[Test, Values([[[], 'no people'], [['A', 'B'], 'AB']])]
-  public function inverse_section_with_short_else($input, $outcome) {
+  public function inverse_iterator_with_short_else($input, $outcome) {
     Assert::equals($outcome, $this->evaluate(
       '{{#people}}{{this}}{{^}}no people{{/people}}',
       ['people' => $input]

--- a/src/test/php/com/handlebarsjs/unittest/InverseOfTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/InverseOfTest.class.php
@@ -1,0 +1,14 @@
+<?php namespace com\handlebarsjs\unittest;
+
+use test\{Assert, Test, Values};
+
+class InverseOfTest extends HelperTest {
+
+  #[Test, Values([[[], 'no people'], [['A', 'B'], 'some people']])]
+  public function inverse_if_with_else($input, $outcome) {
+    Assert::equals($outcome, $this->evaluate(
+      '{{^if people}}no people{{else}}some people{{/if}}',
+      ['people' => $input]
+    ));
+  }
+}

--- a/src/test/php/com/handlebarsjs/unittest/InverseOfTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/InverseOfTest.class.php
@@ -4,10 +4,42 @@ use test\{Assert, Test, Values};
 
 class InverseOfTest extends HelperTest {
 
+  #[Test, Values([[[], 'no people'], [['A', 'B'], 'AB']])]
+  public function inverse_section($input, $outcome) {
+    Assert::equals($outcome, $this->evaluate(
+      '{{#people}}{{this}}{{/people}}{{^people}}no people{{/people}}',
+      ['people' => $input]
+    ));
+  }
+
+  #[Test, Values([[[], 'no people'], [['A', 'B'], 'AB']])]
+  public function inverse_section_with_else($input, $outcome) {
+    Assert::equals($outcome, $this->evaluate(
+      '{{#people}}{{this}}{{else}}no people{{/people}}',
+      ['people' => $input]
+    ));
+  }
+
+  #[Test, Values([[[], 'no people'], [['A', 'B'], 'AB']])]
+  public function inverse_section_with_short_else($input, $outcome) {
+    Assert::equals($outcome, $this->evaluate(
+      '{{#people}}{{this}}{{^}}no people{{/people}}',
+      ['people' => $input]
+    ));
+  }
+
   #[Test, Values([[[], 'no people'], [['A', 'B'], 'some people']])]
   public function inverse_if_with_else($input, $outcome) {
     Assert::equals($outcome, $this->evaluate(
       '{{^if people}}no people{{else}}some people{{/if}}',
+      ['people' => $input]
+    ));
+  }
+
+  #[Test, Values([[[], 'no people'], [['A', 'B'], 'some people']])]
+  public function inverse_if_with_short_else($input, $outcome) {
+    Assert::equals($outcome, $this->evaluate(
+      '{{^if people}}no people{{^}}some people{{/if}}',
       ['people' => $input]
     ));
   }

--- a/src/test/php/com/handlebarsjs/unittest/InverseOfTest.class.php
+++ b/src/test/php/com/handlebarsjs/unittest/InverseOfTest.class.php
@@ -4,10 +4,50 @@ use test\{Assert, Test, Values};
 
 class InverseOfTest extends HelperTest {
 
+  #[Test, Values([[null, 'Guest'], ['Test', 'User Test']])]
+  public function inverse_variable($input, $outcome) {
+    Assert::equals($outcome, $this->evaluate(
+      '{{#person}}User {{.}}{{/person}}{{^person}}Guest{{/person}}',
+      ['person' => $input]
+    ));
+  }
+
+  #[Test, Values([[null, 'Guest'], ['Test', 'User Test']])]
+  public function inverse_variable_with_else($input, $outcome) {
+    Assert::equals($outcome, $this->evaluate(
+      '{{#person}}User {{.}}{{else}}Guest{{/person}}',
+      ['person' => $input]
+    ));
+  }
+
+  #[Test, Values([[null, 'Guest'], ['Test', 'User Test']])]
+  public function inverse_variable_with_short_else($input, $outcome) {
+    Assert::equals($outcome, $this->evaluate(
+      '{{#person}}User {{.}}{{^}}Guest{{/person}}',
+      ['person' => $input]
+    ));
+  }
+
   #[Test, Values([[null, 'Guest'], [['name' => 'Test'], 'User Test']])]
   public function inverse_section($input, $outcome) {
     Assert::equals($outcome, $this->evaluate(
       '{{#person}}User {{name}}{{/person}}{{^person}}Guest{{/person}}',
+      ['person' => $input]
+    ));
+  }
+
+  #[Test, Values([[null, 'Guest'], [['name' => 'Test'], 'User Test']])]
+  public function inverse_section_with_else($input, $outcome) {
+    Assert::equals($outcome, $this->evaluate(
+      '{{#person}}User {{name}}{{else}}Guest{{/person}}',
+      ['person' => $input]
+    ));
+  }
+
+  #[Test, Values([[null, 'Guest'], [['name' => 'Test'], 'User Test']])]
+  public function inverse_section_with_short_else($input, $outcome) {
+    Assert::equals($outcome, $this->evaluate(
+      '{{#person}}User {{name}}{{^}}Guest{{/person}}',
       ['person' => $input]
     ));
   }


### PR DESCRIPTION
A `^` starting a block is an inverse block. Example:

```handlebars
Long version:
{{#person}}User {{name}}{{/person}}{{^person}}Guest{{/person}}

Shorter version:
{{#person}}User {{name}}{{^}}Guest{{/person}}
```

This expression yields:

* "User test" for person=`["name" => "test"]`
* "Guest" for person=`null`

*This fixes the MethodNotImplementedException being raised for these expressions*.